### PR TITLE
changed links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ toolchain.
 
 This repository uses submodules. You need the --recursive option to fetch the submodules automatically
 
-    $ git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
+    $ git clone --recursive https://github.com/sifive/riscv-gnu-toolchain
     
 Alternatively :
 
-    $ git clone https://github.com/riscv/riscv-gnu-toolchain
+    $ git clone https://github.com/sifive/riscv-gnu-toolchain
     $ cd riscv-gnu-toolchain
     $ git submodule update --init --recursive
     


### PR DESCRIPTION
I updated the links to point to the right repositories.

Also it would be great, if the documentation contains the exact build commands to create the same tool chain as provided in binary from SiFive. I need the toolchain on a Raspberry Pi for which no binary package is provided (and a build takes a couple of hours ;-). The first two tries did not contain the special instructions needed to compile the examples for HiFive 1 Rev. B with Freedom Metal.